### PR TITLE
Fix unsafe pgvector typreceive/typsend C stubs

### DIFF
--- a/connect25/src/test/java/org/weaverdb/direct/PgvectorSmokeTest.java
+++ b/connect25/src/test/java/org/weaverdb/direct/PgvectorSmokeTest.java
@@ -57,14 +57,14 @@ public class PgvectorSmokeTest {
     public void vectorSendProducesBinaryPayload() throws Exception {
         try (DBReference conn = DBReference.connect("template1")) {
             try (Statement s = conn.statement(
-                    "select length(vector_send('[1,2,3]'::vector))")) {
+                    "select octet_length(vector_send('[1,2,3]'::vector))")) {
                 Output<Integer> out = s.linkOutput(1, Integer.class);
                 Assertions.assertTrue(s.fetch());
                 // int16 dim + int16 unused + 3 * float4
                 Assertions.assertEquals(16, out.get().intValue());
             }
             try (Statement s = conn.statement(
-                    "select length(halfvec_send('[1,2]'::halfvec))")) {
+                    "select octet_length(halfvec_send('[1,2]'::halfvec))")) {
                 Output<Integer> out = s.linkOutput(1, Integer.class);
                 Assertions.assertTrue(s.fetch());
                 // int16 dim + int16 unused + 2 * float16

--- a/connect25/src/test/java/org/weaverdb/direct/PgvectorSmokeTest.java
+++ b/connect25/src/test/java/org/weaverdb/direct/PgvectorSmokeTest.java
@@ -49,6 +49,30 @@ public class PgvectorSmokeTest {
         }
     }
 
+    /**
+     * typsend must produce a real bytea (dim/unused + float payload), not the
+     * former no-op stub that returned a null pointer.
+     */
+    @Test
+    public void vectorSendProducesBinaryPayload() throws Exception {
+        try (DBReference conn = DBReference.connect("template1")) {
+            try (Statement s = conn.statement(
+                    "select length(vector_send('[1,2,3]'::vector))")) {
+                Output<Integer> out = s.linkOutput(1, Integer.class);
+                Assertions.assertTrue(s.fetch());
+                // int16 dim + int16 unused + 3 * float4
+                Assertions.assertEquals(16, out.get().intValue());
+            }
+            try (Statement s = conn.statement(
+                    "select length(halfvec_send('[1,2]'::halfvec))")) {
+                Output<Integer> out = s.linkOutput(1, Integer.class);
+                Assertions.assertTrue(s.fetch());
+                // int16 dim + int16 unused + 2 * float16
+                Assertions.assertEquals(8, out.get().intValue());
+            }
+        }
+    }
+
     private static void exec(DBReference conn, String sql) throws Exception {
         try (Statement s = conn.statement(sql)) {
             s.execute();

--- a/mtpgsql/src/backend/access/pgvector/port-stubs/pgvector_compat.h
+++ b/mtpgsql/src/backend/access/pgvector/port-stubs/pgvector_compat.h
@@ -26,14 +26,13 @@
 
 #define PG_RETURN_BYTEA_P(x)    return (Datum)0 /* replaced below after PG7 arg wiring */
 #define PG_RETURN_POINTER(x)    return (Datum)0
-#define pq_sendfloat4(buf,f)    ((void)0)
-#define pq_endtypsend(buf)      ((void*)0)
-#define pq_begin_typsend()      ((StringInfo)0)
 
 #define PG_RETURN_INT32(x)      return (Datum)0
-#define pq_getmsgint(buf,sz)    (0)
-#define pq_getmsgfloat4(buf)    (0.0f)
-#define pq_begintypsend(buf)    ((void)0)
+/*
+ * pq_begintypsend / pq_endtypsend / pq_sendfloat4 / pq_getmsgint /
+ * pq_getmsgfloat4 are real helpers in libpq/pqformat.c (typreceive/typsend).
+ * Do not stub them: no-ops returned NULL bytea / zero vectors.
+ */
 
 #define float_overflow_error()  ((void)0)
 #define float_underflow_error() ((void)0)

--- a/mtpgsql/src/backend/lib/stringinfo.c
+++ b/mtpgsql/src/backend/lib/stringinfo.c
@@ -57,6 +57,7 @@ initStringInfo(StringInfo str)
 			 "initStringInfo: Out of memory (%d bytes requested)", size);
 	str->maxlen = size;
 	str->len = 0;
+	str->cursor = 0;
 	str->data[0] = '\0';
 }
 

--- a/mtpgsql/src/backend/libpq/pqformat.c
+++ b/mtpgsql/src/backend/libpq/pqformat.c
@@ -232,6 +232,127 @@ pq_endmessage(StringInfo buf)
 }
 
 /* --------------------------------
+ *		pq_sendfloat4		- append a float4 to a StringInfo buffer
+ *
+ * External float4 binary representation matches int4 byte order (IEEE-754).
+ * --------------------------------
+ */
+void
+pq_sendfloat4(StringInfo buf, float f)
+{
+	union
+	{
+		float		f;
+		uint32		i;
+	}			swap;
+
+	swap.f = f;
+	pq_sendint(buf, (int) swap.i, 4);
+}
+
+/* --------------------------------
+ *		pq_begintypsend		- initialize for constructing a bytea result
+ * --------------------------------
+ */
+void
+pq_begintypsend(StringInfo buf)
+{
+	initStringInfo(buf);
+	/* Reserve four bytes for the bytea length word */
+	appendStringInfoCharMacro(buf, '\0');
+	appendStringInfoCharMacro(buf, '\0');
+	appendStringInfoCharMacro(buf, '\0');
+	appendStringInfoCharMacro(buf, '\0');
+}
+
+/* --------------------------------
+ *		pq_endtypsend		- finish constructing a bytea result
+ *
+ * The data buffer is returned as the palloc'd bytea value.
+ * --------------------------------
+ */
+struct varlena *
+pq_endtypsend(StringInfo buf)
+{
+	struct varlena *result = (struct varlena *) buf->data;
+
+	Assert(buf->len >= VARHDRSZ);
+	SETVARSIZE(result, buf->len);
+
+	return result;
+}
+
+/* --------------------------------
+ *		pq_copymsgbytes		- copy raw data from a message buffer
+ * --------------------------------
+ */
+void
+pq_copymsgbytes(StringInfo msg, char *buf, int datalen)
+{
+	if (datalen < 0 || datalen > (msg->len - msg->cursor))
+		elog(ERROR, "insufficient data left in message");
+
+	memcpy(buf, &msg->data[msg->cursor], datalen);
+	msg->cursor += datalen;
+}
+
+/* --------------------------------
+ *		pq_getmsgint		- get a binary integer from a message buffer
+ *
+ * Values are treated as unsigned.  Byte order matches pq_sendint so that
+ * typsend/typreceive round-trips agree with this fork's FE endian rules.
+ * --------------------------------
+ */
+unsigned int
+pq_getmsgint(StringInfo msg, int b)
+{
+	unsigned int result;
+	unsigned char n8;
+	uint16		n16;
+	uint32		n32;
+
+	switch (b)
+	{
+		case 1:
+			pq_copymsgbytes(msg, (char *) &n8, 1);
+			result = n8;
+			break;
+		case 2:
+			pq_copymsgbytes(msg, (char *) &n16, 2);
+			result = (unsigned int) ((PG_PROTOCOL_MAJOR(FrontendProtocol) == 0) ?
+									ntoh_s(n16) : ntohs(n16));
+			break;
+		case 4:
+			pq_copymsgbytes(msg, (char *) &n32, 4);
+			result = (unsigned int) ((PG_PROTOCOL_MAJOR(FrontendProtocol) == 0) ?
+									ntoh_l(n32) : ntohl(n32));
+			break;
+		default:
+			elog(ERROR, "pq_getmsgint: unsupported size %d", b);
+			result = 0;
+			break;
+	}
+	return result;
+}
+
+/* --------------------------------
+ *		pq_getmsgfloat4		- get a float4 from a message buffer
+ * --------------------------------
+ */
+float
+pq_getmsgfloat4(StringInfo msg)
+{
+	union
+	{
+		float		f;
+		uint32		i;
+	}			swap;
+
+	swap.i = pq_getmsgint(msg, 4);
+	return swap.f;
+}
+
+/* --------------------------------
  *		pq_puttextmessage - generate a MULTIBYTE-converted message in one step
  *
  *		This is the same as the pqcomm.c routine pq_putmessage, except that

--- a/mtpgsql/src/include/catalog/pg_proc.h
+++ b/mtpgsql/src/include/catalog/pg_proc.h
@@ -1042,6 +1042,19 @@ DESCR("quantize vector to bit");
 DATA(insert OID = 2338 (  halfvec_binary_quantize	   PGUID 11 f t t 1 f 1562 "1844" 100 0 0 100  halfvec_binary_quantize - ));
 DESCR("quantize halfvec to bit");
 
+DATA(insert OID = 2339 (  vector_recv		   PGUID 11 f t t 3 f 1842 "0 0 23" 100 0 0 100  vector_recv - ));
+DESCR("vector binary receive");
+DATA(insert OID = 2340 (  vector_send		   PGUID 11 f t t 1 f 17 "1842" 100 0 0 100  vector_send - ));
+DESCR("vector binary send");
+DATA(insert OID = 2341 (  halfvec_recv		   PGUID 11 f t t 3 f 1844 "0 0 23" 100 0 0 100  halfvec_recv - ));
+DESCR("halfvec binary receive");
+DATA(insert OID = 2342 (  halfvec_send		   PGUID 11 f t t 1 f 17 "1844" 100 0 0 100  halfvec_send - ));
+DESCR("halfvec binary send");
+DATA(insert OID = 2343 (  sparsevec_recv	   PGUID 11 f t t 3 f 1846 "0 0 23" 100 0 0 100  sparsevec_recv - ));
+DESCR("sparsevec binary receive");
+DATA(insert OID = 2344 (  sparsevec_send	   PGUID 11 f t t 1 f 17 "1846" 100 0 0 100  sparsevec_send - ));
+DESCR("sparsevec binary send");
+
 #define F_VECTORIN	2237
 #define F_VECTOROUT	2238
 #define F_L2_DISTANCE	2240
@@ -1056,6 +1069,12 @@ DESCR("quantize halfvec to bit");
 #define F_BIT_TO_BYTEA	2298
 #define F_BINARY_QUANTIZE	2337
 #define F_HALFVEC_BINARY_QUANTIZE	2338
+#define F_VECTOR_RECV	2339
+#define F_VECTOR_SEND	2340
+#define F_HALFVEC_RECV	2341
+#define F_HALFVEC_SEND	2342
+#define F_SPARSEVEC_RECV	2343
+#define F_SPARSEVEC_SEND	2344
 
 DATA(insert OID = 449 (  hashint2		   PGUID 11 f t t 1 f 23 "21" 100 0 0 100  hashint2 - ));
 DESCR("hash");

--- a/mtpgsql/src/include/catalog/pg_type.h
+++ b/mtpgsql/src/include/catalog/pg_type.h
@@ -168,7 +168,7 @@ DESCR("single character");
 DATA(insert OID = 1841 (	schar	   PGUID  1   1 t b t \x2C 0   0 charin charout charin charout c _null_ ));
 DESCR("single character");
 
-DATA(insert OID = 1842 (	vector	   PGUID -1  -1 f b t \x2C 0  18 vector_in vector_out vector_in vector_out i _null_ ));
+DATA(insert OID = 1842 (	vector	   PGUID -1  -1 f b t \x2C 0  18 vector_in vector_out vector_recv vector_send i _null_ ));
 DESCR("float vector for similarity search");
 #define VECTOROID		1842
 
@@ -176,7 +176,7 @@ DATA(insert OID = 1843 (  _vector	 PGUID -1  -1 f b t \x2C 0 1842 array_in array
 DESCR("array of vector");
 #define VECTORARRAYOID	1843
 
-DATA(insert OID = 1844 (	halfvec	   PGUID -1  -1 f b t \x2C 0  18 halfvec_in halfvec_out halfvec_in halfvec_out i _null_ ));
+DATA(insert OID = 1844 (	halfvec	   PGUID -1  -1 f b t \x2C 0  18 halfvec_in halfvec_out halfvec_recv halfvec_send i _null_ ));
 DESCR("half-precision float vector for similarity search");
 #define HALFVECOID		1844
 
@@ -184,7 +184,7 @@ DATA(insert OID = 1845 (  _halfvec	 PGUID -1  -1 f b t \x2C 0 1844 array_in arra
 DESCR("array of halfvec");
 #define HALFVECARRAYOID	1845
 
-DATA(insert OID = 1846 (	sparsevec   PGUID -1  -1 f b t \x2C 0  18 sparsevec_in sparsevec_out sparsevec_in sparsevec_out i _null_ ));
+DATA(insert OID = 1846 (	sparsevec   PGUID -1  -1 f b t \x2C 0  18 sparsevec_in sparsevec_out sparsevec_recv sparsevec_send i _null_ ));
 DESCR("sparse float vector for similarity search");
 #define SPARSEVECOID	1846
 

--- a/mtpgsql/src/include/lib/stringinfo.h
+++ b/mtpgsql/src/include/lib/stringinfo.h
@@ -27,6 +27,7 @@
  *				string size (including the terminating '\0' char) that we can
  *				currently store in 'data' without having to reallocate
  *				more space.  We must always have maxlen > len.
+ *		cursor	is a read position for pq_getmsg* parsers (typreceive).
  *-------------------------
  */
 typedef struct StringInfoData
@@ -34,6 +35,7 @@ typedef struct StringInfoData
 	char	   *data;
 	int			len;
 	int			maxlen;
+	int			cursor;
 } StringInfoData;
 
 typedef StringInfoData *StringInfo;

--- a/mtpgsql/src/include/libpq/pqformat.h
+++ b/mtpgsql/src/include/libpq/pqformat.h
@@ -22,7 +22,15 @@ extern void pq_sendbytes(StringInfo buf, const char *data, int datalen);
 extern void pq_sendcountedtext(StringInfo buf, const char *str, int slen);
 extern void pq_sendstring(StringInfo buf, const char *str);
 extern void pq_sendint(StringInfo buf, int i, int b);
+extern void pq_sendfloat4(StringInfo buf, float f);
 extern void pq_endmessage(StringInfo buf);
+
+/* typsend / typreceive helpers (external binary type I/O) */
+extern void pq_begintypsend(StringInfo buf);
+extern struct varlena *pq_endtypsend(StringInfo buf);
+extern void pq_copymsgbytes(StringInfo msg, char *buf, int datalen);
+extern unsigned int pq_getmsgint(StringInfo msg, int b);
+extern float pq_getmsgfloat4(StringInfo msg);
 
 extern int	pq_puttextmessage(char msgtype, const char *str);
 

--- a/pgjava_c/src/test/java/org/weaverdb/PgvectorSmokeTest.java
+++ b/pgjava_c/src/test/java/org/weaverdb/PgvectorSmokeTest.java
@@ -57,7 +57,7 @@ public class PgvectorSmokeTest {
     public void vectorSendProducesBinaryPayload() throws Exception {
         try (DBReference conn = DBReferenceManager.connect("template1")) {
             try (Statement s = conn.statement(
-                    "select length(vector_send('[1,2,3]'::vector))")) {
+                    "select octet_length(vector_send('[1,2,3]'::vector))")) {
                 Output<Integer> out = s.linkOutput(1, Integer.class);
                 s.execute();
                 Assertions.assertTrue(s.fetch());
@@ -65,7 +65,7 @@ public class PgvectorSmokeTest {
                 Assertions.assertEquals(16, out.get().intValue());
             }
             try (Statement s = conn.statement(
-                    "select length(halfvec_send('[1,2]'::halfvec))")) {
+                    "select octet_length(halfvec_send('[1,2]'::halfvec))")) {
                 Output<Integer> out = s.linkOutput(1, Integer.class);
                 s.execute();
                 Assertions.assertTrue(s.fetch());

--- a/pgjava_c/src/test/java/org/weaverdb/PgvectorSmokeTest.java
+++ b/pgjava_c/src/test/java/org/weaverdb/PgvectorSmokeTest.java
@@ -49,6 +49,32 @@ public class PgvectorSmokeTest {
         }
     }
 
+    /**
+     * typsend must produce a real bytea (dim/unused + float4 payload), not the
+     * former no-op stub that returned a null pointer.
+     */
+    @Test
+    public void vectorSendProducesBinaryPayload() throws Exception {
+        try (DBReference conn = DBReferenceManager.connect("template1")) {
+            try (Statement s = conn.statement(
+                    "select length(vector_send('[1,2,3]'::vector))")) {
+                Output<Integer> out = s.linkOutput(1, Integer.class);
+                s.execute();
+                Assertions.assertTrue(s.fetch());
+                // int16 dim + int16 unused + 3 * float4
+                Assertions.assertEquals(16, out.get().intValue());
+            }
+            try (Statement s = conn.statement(
+                    "select length(halfvec_send('[1,2]'::halfvec))")) {
+                Output<Integer> out = s.linkOutput(1, Integer.class);
+                s.execute();
+                Assertions.assertTrue(s.fetch());
+                // int16 dim + int16 unused + 2 * float16
+                Assertions.assertEquals(8, out.get().intValue());
+            }
+        }
+    }
+
     private static void exec(DBReference conn, String sql) throws Exception {
         try (Statement s = conn.statement(sql)) {
             s.execute();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On `add_pgvector`, `pgvector_compat.h` stubbed the binary type I/O helpers as no-ops:

- `pq_begintypsend` / `pq_endtypsend` / `pq_sendfloat4` → empty / NULL
- `pq_getmsgint` / `pq_getmsgfloat4` → `0` / `0.0f`

That made `vector_send` / `halfvec_send` / `sparsevec_send` return a null bytea pointer and `*_recv` silently build zeroed values — unsafe if those entry points are ever called.

## Fix

1. Add a `cursor` field to `StringInfoData` (needed for message parsing).
2. Implement real helpers in `libpq/pqformat.c` matching modern PostgreSQL typsend/typreceive semantics (round-trip endianness aligned with this fork’s `pq_sendint`).
3. Remove the no-op macros from `pgvector_compat.h`.
4. Register `vector_recv`/`vector_send`, `halfvec_recv`/`halfvec_send`, `sparsevec_recv`/`sparsevec_send` in `pg_proc` and wire them as `typreceive`/`typsend` on the vector types (replacing the previous `*_in`/`*_out` placeholders).
5. Smoke-test that `vector_send` / `halfvec_send` produce the expected binary payload sizes via `octet_length`.

## Note

`bytea_to_vector` / `vector_to_bytea` remain the preferred app-facing native-endian blob path; `*_send`/`*_recv` are the PostgreSQL external binary format.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbea7-714c-70d9-bdce-5277dc9c73c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbea7-714c-70d9-bdce-5277dc9c73c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

