### PR TITLE
Defer hard commit until after sync when shadow logging is off

### DIFF
--- a/mtpgsql/src/backend/env/dbwriter.c
+++ b/mtpgsql/src/backend/env/dbwriter.c
@@ -731,7 +731,19 @@ int LogWriteGroup(WriteGroup cart) {
         releasecount = LogBuffers(cart);
     }
 
-    if ( cart->dotransaction ) {
+    /*
+     * Harden commits only when shadow logging made the dirty pages
+     * recoverable.  Crash before SyncBuffers is then repaired by FPI
+     * replay, which restores heap and index pages together — so a
+     * committed xid cannot leave an orphaned heap item without its
+     * index entry.
+     *
+     * Without shadow logging there is no replay safety net.  Leave
+     * dotransaction set and harden in SyncWriteGroup after the pages
+     * are synced.  A mid-sync crash keeps the xid soft; TransRecover
+     * aborts it, so any heap-only residue is uncommitted and safe.
+     */
+    if ( cart->dotransaction && logging ) {
         LogTransactions(cart);
         for (x=0;x<cart->numberOfTrans;x++) {
             if ( cart->WaitingThreads[x] && !cart->wait_for_sync[x] ) {
@@ -743,7 +755,8 @@ int LogWriteGroup(WriteGroup cart) {
 
     pthread_mutex_lock(&cart->checkpoint);
     cart->currstate = LOGGED;
-    cart->dotransaction = false;
+    if ( logging )
+        cart->dotransaction = false;
     pthread_cond_broadcast(&cart->broadcaster);
     pthread_mutex_unlock(&cart->checkpoint);
     
@@ -760,9 +773,15 @@ int SyncWriteGroup(WriteGroup cart) {
     
     ClearLogs(cart);
     
+    /*
+     * No-shadow-log path: harden soft commits only after data pages
+     * and fsyncs completed.  Orphaned heap items from a crash above
+     * remain soft and become aborts on restart.
+     */
     if (cart->dotransaction && TransactionSystemInitialized) {
         trans_logged = LogTransactions(cart);
-        elog(DEBUG, "logged %d transactions", trans_logged);
+        elog(DEBUG, "logged %d transactions after sync", trans_logged);
+        cart->dotransaction = false;
     }
     
     for (x=0;x<cart->numberOfTrans;x++) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prevents **committed orphaned heap items** (heap page durable, index page not) when DBWriter crashes mid-`SyncBuffers` without a shadow-log safety net.

### Behavior

| Mode | When xid hardens | Crash mid-sync |
|------|------------------|----------------|
| Shadow logging on (multiuser) | After `LogBuffers` (unchanged) | FPI replay restores heap + index together |
| Shadow logging off | After `SyncBuffers` + `CommitPackage` | Xid stays soft → `TransRecover` aborts → heap-only residue is uncommitted |

Soft commits already made orphaned heap items safe when the xid never hardened. The hole was hardening **before** data sync when there were no FPIs to replay. `SyncWriteGroup` already had a post-sync `LogTransactions` hook; `LogWriteGroup` was clearing `dotransaction` too early for the no-log path.

### Out of scope

- Dangling index TIDs (still need `btrecoverpage` / ANN recoverpage)
- pgvector HNSW/IVFFlat graph repair
- Changing multiuser durability (hard commit after FPI log remains)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc511-b061-7f9b-858a-09dde67427eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc511-b061-7f9b-858a-09dde67427eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

